### PR TITLE
chore/remove uvloop dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "typing-extensions==4.14.1",
     "urllib3==2.5.0",
     "uvicorn==0.30.6",
-    "uvloop==0.21.0",
     "watchfiles==1.1.0",
     "websockets==15.0.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,8 +111,6 @@ uvicorn==0.30.6
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
-uvloop==0.21.0
-    # via uvicorn
 watchfiles==1.1.0
     # via uvicorn
 websockets==15.0.1


### PR DESCRIPTION
# Lack of Windows support for UVLoop Dependencies

### Housekeeping
Closes #5  (Issue)
Depends on #7 

## Why remove `uvloop`?

We're removing `uvloop` because:

- **Incompatibility with Windows**: `uvloop` doesn't support Windows, which blocks Windows box contributors from running the project locally.
- **It's not required**: Neither FastAPI nor Uvicorn require `uvloop`. It’s an optional performance enhancement, not a core dependency.

This cleanup makes the project more accessible and easier to contribute to across all operating systems.
