### PR TITLE
chore - update python multipart to match requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic-core==2.20.1",
     "pygments==2.19.2",
     "python-dotenv==1.0.1",
-    "python-multipart==0.0.17",
+    "python-multipart==0.0.20",
     "pyyaml==6.0.2",
     "rich==14.0.0",
     "rich-toolkit==0.14.8",


### PR DESCRIPTION
## Description
Update python-multipart (see description on #5 and #6 
Closes #6 
* part 2

## Screenshots/Videos
<img width="274" height="149" alt="image" src="https://github.com/user-attachments/assets/620c7d1c-65fe-4b44-8159-018e3b1552c2" />


## How to Test
Steps to reproduce or test:
1. requirements.txt has a line `python-multipart==0.0.20`
2. pyproject.toml has a line `"python-multipart==0.0.17",`
3. run `uv sync`