### PR TITLE
refactor: allow Supabase to assign default value for status

### DIFF
--- a/app/models/status_update.py
+++ b/app/models/status_update.py
@@ -13,7 +13,7 @@ class StatusEnum(str, enum.Enum):
 
 class StatusUpdateBase(SQLModel):
     booking_id: UUID
-    status: StatusEnum
+    status: Optional[StatusEnum]
 
 class StatusUpdate(StatusUpdateBase, table=True):
     __tablename__ = "status_updates"


### PR DESCRIPTION
## Description
This PR updates the `status` field on the `status_updates` table to optional so that Supabase can control and apply the default value of `confirmed` when no value is provided. 

This is cleaner, more flexible and allows us to move status API management to Supabase instead of depending on the client or backend logic.

## Screenshots/Videos
<img width="494" height="217" alt="image" src="https://github.com/user-attachments/assets/9d57abbd-bdf1-4019-8f8e-e2f4d735f307" />

## How to Test
N/A