### PR TITLE
Fix Provider Routes (provider/all, provider/provider_id)

### DIFF
--- a/app/models/provider.py
+++ b/app/models/provider.py
@@ -11,7 +11,7 @@ from sqlmodel import (
     Relationship,
 )
 
-from app.models.service import ServiceRead
+from app.models.service import ServiceResponseProvider
 from app.models.reviews import ReviewRead
 
 if TYPE_CHECKING:
@@ -24,7 +24,6 @@ class ProviderBase(SQLModel):
     last_name: str
     company_name: Optional[str] = None
     phone_number: Optional[str] = None
-    services_subcategories: Optional[str] = None
 
 
 # Full model for DB
@@ -66,7 +65,7 @@ class ProviderPublicRead(SQLModel):
     id: UUID
     phone_number: Optional[str] = None
     company_name: Optional[str] = None
-    services: list[ServiceRead]
+    services: list[ServiceResponseProvider]
 
 
 class ProviderResponseDetail(ProviderPublicRead):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -56,6 +56,14 @@ class ServiceUpdate(SQLModel):
     duration: Optional[int] = None
 
 
+class ServiceResponseProvider(SQLModel):
+    id: UUID
+    service_title: str
+    service_description: Optional[str] = None
+    pricing: float
+    duration: int 
+    category: Optional[str]
+
+
 class ServiceRead(ServiceBase):
     id: UUID
-    services_subcategories: Optional[str] = None


### PR DESCRIPTION
## Description
Resolved errors in the provider routes by creating a new Service class that `GET providers/all` and `GET providers/{provider_id}` can use, given that neither route needs service_subcategories.

## Screenshots/Videos

`GET providers/all`

<img width="1397" height="682" alt="Screenshot 2025-07-26 at 6 35 37 PM" src="https://github.com/user-attachments/assets/87c8a11f-14b9-47be-8ddf-54314f0cf3f3" />

`GET providers/{provider_id}`

<img width="1376" height="683" alt="Screenshot 2025-07-26 at 6 36 21 PM" src="https://github.com/user-attachments/assets/9db5711b-02bc-46bc-873f-412e3f10a198" />

`GET provider/all/{category_name}`

<img width="1372" height="683" alt="Screenshot 2025-07-26 at 6 38 15 PM" src="https://github.com/user-attachments/assets/8ee97d4f-beb4-480e-9f9e-26564aaca31b" />

## How to Test
Steps to reproduce or test:
1. Run the backend
2. Test routes on SwaggerUI
    - Test `GET providers/all`
    - Test `GET providers/{provider_id}`
    - Test `GET provider/all/{category_name}`