### PR TITLE
typed service_categories in services to be an array of strings

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from app.models.provider import Provider
     from app.models.booking import Booking
 
+
 class ServiceEnum(Enum):
     HOUSE_CLEANING = "housecleaning"
     LAWN_AND_GARDEN = "lawnandgarden"
@@ -24,7 +25,7 @@ class ServiceBase(SQLModel):
     pricing: float
     duration: int  # in minutes
     category: Optional[str]
-    services_subcategories: Optional[str] = None
+    services_subcategories: List[str]
 
 
 class Service(ServiceBase, table=True):
@@ -45,6 +46,7 @@ class Service(ServiceBase, table=True):
     provider: "Provider" = Relationship(back_populates="services")
     bookings: List["Booking"] = Relationship(back_populates="service")
 
+
 class ServiceCreate(ServiceBase):
     provider_id: UUID
 
@@ -61,7 +63,7 @@ class ServiceResponseProvider(SQLModel):
     service_title: str
     service_description: Optional[str] = None
     pricing: float
-    duration: int 
+    duration: int
     category: Optional[str]
 
 


### PR DESCRIPTION
## Description
Brief description of the issue or feature.
Hotfix to type the service_categories array as an array of strings instead of just a single string value 
## Screenshots/Videos

## How to Test
Steps to reproduce or test:
1. Only used for schema design 
